### PR TITLE
fix: breaking behaviour with inline tags

### DIFF
--- a/lib/html2markdown/converter.ex
+++ b/lib/html2markdown/converter.ex
@@ -49,11 +49,21 @@ defmodule Html2Markdown.Converter do
           if acc == [] do
             [iodata]
           else
-            [acc, "\n\n", iodata]
+            [acc, get_spacing_between_elements(node), iodata]
           end
       end
     end)
   end
+
+  defp get_spacing_between_elements({tag, _, _}) when is_binary(tag) do
+    if ElementTypes.block_element?(tag) do
+      "\n\n"
+    else
+      " "
+    end
+  end
+
+  defp get_spacing_between_elements(_node), do: " "
 
   # Process nodes to iolist for better performance
   defp process_node_to_iolist({"h1", _, children}, opts),
@@ -426,7 +436,7 @@ defmodule Html2Markdown.Converter do
   defp process_ordered_list_item_to_iolist(other, _index, opts),
     do: process_node_to_iolist(other, opts)
 
-  # Context-aware processing for better spacing control  
+  # Context-aware processing for better spacing control
   defp process_children_with_context(children, opts, context) do
     final_context = determine_context(children, context)
 

--- a/test/html2markdown_test.exs
+++ b/test/html2markdown_test.exs
@@ -543,4 +543,36 @@ defmodule Html2MarkdownTest do
       assert Html2Markdown.convert(html) == expected
     end
   end
+
+  describe "HTML tags with normal text" do
+    test "emphasis tag" do
+      html = """
+      <em>Emphasis</em> normal text
+      """
+
+      expected = "*Emphasis* normal text"
+
+      assert Html2Markdown.convert(html) == expected
+    end
+
+    test "strong tag" do
+      html = """
+      <strong>Bold</strong> normal text
+      """
+
+      expected = "**Bold** normal text"
+
+      assert Html2Markdown.convert(html) == expected
+    end
+
+    test "span tag" do
+      html = """
+      <span>Span text</span> normal text
+      """
+
+      expected = "Span text normal text"
+
+      assert Html2Markdown.convert(html) == expected
+    end
+  end
 end

--- a/test/support/fixtures/elixir.md
+++ b/test/support/fixtures/elixir.md
@@ -79,9 +79,7 @@ Here is an example of **strong text** and *emphasized text*.
 
 Subscript: H <sub>2</sub> O
 
-Superscript: E = mc <sup>2</sup>
-
-
+Superscript: E = mc <sup>2</sup> 
 
 ---
 


### PR DESCRIPTION
Don't add double new line after a inline tag mixed with text.

## Summary by Sourcery

Fix spacing logic between HTML elements by replacing hard-coded newlines with context-aware spacing, add supporting tests, and update fixtures

Bug Fixes:
- Prevent double new lines after inline HTML tags when mixed with text

Enhancements:
- Introduce get_spacing_between_elements to choose space or newline based on element type

Tests:
- Add unit tests for emphasis, strong, and span tags followed by text to verify inline spacing

Chores:
- Update markdown fixture to remove extra blank lines around superscript tag